### PR TITLE
Remove accept header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hckrnews/express-callback",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hckrnews/express-callback",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "license": "MIT",
             "dependencies": {
                 "@hckrnews/objects": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hckrnews/express-callback",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "description": "Express callback",
     "files": [
         "src/error-status.js",

--- a/src/__tests__/express-callback.unit.js
+++ b/src/__tests__/express-callback.unit.js
@@ -87,7 +87,9 @@ describe('Test the express callback', () => {
         const currentRes = { ...res, values: { ...res.values } };
 
         const controller = () => ({
-            headers: {},
+            headers: {
+                'Content-Type': 'text/csv',
+            },
             statusCode: 200,
             body: {},
             attachment: true,
@@ -126,6 +128,9 @@ describe('Test the express callback', () => {
         const controller = () => ({
             statusCode: 200,
             body: {},
+            headers: {
+                'Content-Type': 'text/xml',
+            },
         });
 
         const expressCallback = makeExpressCallback({

--- a/src/express-callback.js
+++ b/src/express-callback.js
@@ -20,10 +20,10 @@ export default function makeExpressCallback({
                 meta,
             });
 
+            // also check if we can auto use the accept header
+            // context.request.headers.accept
             const contentType =
-                response?.headers?.['Content-Type'] ??
-                context?.request?.headers?.accept ??
-                'application/json';
+                response?.headers?.['Content-Type'] ?? 'application/json';
 
             const httpResponse = buildResponse(
                 response,


### PR DESCRIPTION
Only use header from controller response.
So controller should handle the content type if it isnt json.